### PR TITLE
Fixed the typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ command line and the task function.
 
 ```python
 @task
-@task.set_argument('source', help='The source where you come from', choice=('Tokyo', 'Osaka'), dest='source')
+@task.set_argument('source', help='The source where you come from', choices=('Tokyo', 'Osaka'), dest='source')
 @task.set_argument('--speed', '-s', help='The speed you wanna run', type=int, dest='speed')
 def run(source, destination, speed=42):
     print('Run from {0} to {1} by speed={2}'.format(source, destination, speed))


### PR DESCRIPTION
Looks like there is a typo as regarding the 'choices' option of the task.set_argument in the README (which use the word 'choice' instead of 'choices') 
